### PR TITLE
Fix when cert server does not request NTLM auth

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -63,7 +63,10 @@ class HTTPRelayClient(ProtocolClient):
                 return False
         except (KeyError, TypeError):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)
-            return False
+            if self.serverConfig.isADCSAttack:
+                LOG.info('IIS cert server may allow anonymous authentication, sending NTLM auth anyways')
+            else:
+                return False
 
         #Negotiate auth
         negotiate = base64.b64encode(negotiateMessage).decode("ascii")


### PR DESCRIPTION
Bumped into this scenario on a pentest and made a couple edits to allow the ADCS attack to still run.

If the IIS cert server is configured to allow anonymous authentication and Windows NTLM auth, the cert server will default to anonymous auth and will not prompt for NTLM authentication.

![2021-08-03_20-55-41](https://user-images.githubusercontent.com/37981031/128214138-bbe49a6f-19b4-4181-99b8-eb0f0cfefb85.png)

When ntlmrelayx encounters this, it won't relay the authentication because it's not requested by the cert server:

![2021-08-03_22-51-38](https://user-images.githubusercontent.com/37981031/128214376-0c8c6a43-6311-4b82-ae8f-8f6b1f3e6a22.png)

I've added a small fix into the `httprelayclient` to send NTLM authentication, even if not requested, when performing the ADCS attack. This allows the attack to generate a certificate:

![2021-08-04_00-18-31](https://user-images.githubusercontent.com/37981031/128214655-17aad262-27c7-4841-a332-a0bca76f2de1.png)

Also added in some code from [this](https://github.com/dirkjanm/PKINITtools/blob/master/ntlmrelayx/httpattack.py) implementation of the attack to prevent clients from being attacked multiple times and causing multiple certificates to be generated.
